### PR TITLE
minor installation clarifications / tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ DiSECt is a simulator for the cutting of deformable materials. It uses the Finit
 * PyTorch 1.4.0 or higher
 * Pixar USD lib (for visualization)
 
-Pre-built USD Python libraries can be downloaded from https://developer.nvidia.com/usd, once they are downloaded you should follow the instructions to add them to your `PYTHONPATH` environment variable. Besides using the provided basic visualizer implemented using pyvista, DiSECt can generate USD files for rendering, e.g. in NVIDIA Omniverse™ or usdview.
+Pre-built USD Python libraries can be downloaded from https://developer.nvidia.com/usd, once they are downloaded and extracted, you should follow the instructions in the corresponding `README.txt` to add the pre-built libraries to your `PYTHONPATH` environment variable. Besides using the provided basic visualizer implemented using pyvista, DiSECt can generate USD files for rendering, e.g. in NVIDIA Omniverse™ or usdview.
 
 ### Using the built-in backend
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ PyQt5==5.15.4
 tensorboardX==2.4
 urdfpy==0.0.22
 git+https://github.com/patrick-kidger/torchcubicspline.git@master#egg=torchcubicspline
+ninja==1.10.2.2


### PR DESCRIPTION
Hi @eric-heiden

I added in a minor installation change. I was running a Python 3.7 conda env on Ubuntu 18, and was running your basic example after the installation steps (including `pip install -r requirements.txt`):

```
(disect) seita@takeshi:~/DiSECt (main) $ python examples/basic_cutting.py 
Rebuilding kernels
Traceback (most recent call last):
  File "examples/basic_cutting.py", line 20, in <module>
    from cutting import load_settings, SlicingMotion, CuttingSim
  File "/home/seita/DiSECt/cutting/__init__.py", line 10, in <module>
    from .cutting_sim import *
  File "/home/seita/DiSECt/cutting/cutting_sim.py", line 25, in <module>
    from cutting.urdf_loader import load_urdf
  File "/home/seita/DiSECt/cutting/urdf_loader.py", line 12, in <module>
    import dflex as df
  File "/home/seita/DiSECt/dflex/__init__.py", line 15, in <module>
    kernel_init()
  File "/home/seita/DiSECt/dflex/sim.py", line 47, in kernel_init
    kernels = df.compile()
  File "/home/seita/DiSECt/dflex/adjoint.py", line 1934, in compile
    with_pytorch_error_handling=False)
  File "/home/seita/miniconda3/envs/disect/lib/python3.7/site-packages/torch/utils/cpp_extension.py", line 1285, in load_inline
    keep_intermediates=keep_intermediates)
  File "/home/seita/miniconda3/envs/disect/lib/python3.7/site-packages/torch/utils/cpp_extension.py", line 1347, in _jit_compile
    is_standalone=is_standalone)
  File "/home/seita/miniconda3/envs/disect/lib/python3.7/site-packages/torch/utils/cpp_extension.py", line 1418, in _write_ninja_file_and_build_library
    verify_ninja_availability()
  File "/home/seita/miniconda3/envs/disect/lib/python3.7/site-packages/torch/utils/cpp_extension.py", line 1474, in verify_ninja_availability
    raise RuntimeError("Ninja is required to load C++ extensions")
RuntimeError: Ninja is required to load C++ extensions
(disect) seita@takeshi:~/DiSECt (main) $
```

The fix is to do a simple `pip install ninja`. I've put this in the `requirements.txt`. (If it would help, I can also write a more detailed overview of how I installed this to make it reproducible in case you don't experience this on your end.)

I've also put a slight clarification into where the instructions are for installing USD libraries in `README.md`. It might not be as clear on a first glance.